### PR TITLE
upgrade ES package, bump

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures elasticsearch'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.1'
+version '0.1.2'
 
 depends 'ele-apt'
 depends 'iptables'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,7 +36,9 @@ end
 # Add intapt repository that has an `elasticsearch` package. Upstream does not provide one
 include_recipe 'ele-apt'
 
-package 'elasticsearch'
+package 'elasticsearch' do
+  action :upgrade
+end
 
 directory '/etc/elasticsearch' do
   owner 'root'


### PR DESCRIPTION
Upgrade `elasticsearch`, don't just install.

Related:
- [x] add latest [`elasticsearch-1.7.3.deb`](https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.3.deb) to `intapt.k1k.me`
