### PR TITLE
update ES path to match upstream

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures elasticsearch'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.2'
+version '0.1.3'
 
 depends 'ele-apt'
 depends 'iptables'

--- a/templates/default/sv-elasticsearch-run.erb
+++ b/templates/default/sv-elasticsearch-run.erb
@@ -6,7 +6,7 @@ ulimit -n 256000
 # ElasticSearch work directory
 export WORK_DIR=/tmp/elasticsearch
 
-exec chpst -u elasticsearch:elasticsearch /opt/elasticsearch/bin/elasticsearch \
+exec chpst -u elasticsearch:elasticsearch /usr/share/elasticsearch/bin/elasticsearch \
                                           -Des.config=/etc/elasticsearch/elasticsearch.yml \
                                           -Xmx<%= node['elasticsearch']['es_max_mem'] %> \
                                           -Xms<%= node['elasticsearch']['es_min_mem'] %> \


### PR DESCRIPTION
Moving to the upstream elasticsearch package moves the default placement of the binary.

Merging and deploying to all elasticsearch boxes (including raxvm) will fix any ES service issues.

```shell
root@dev-maas-dev-dev0:/home/vagrant# apt-cache show elasticsearch | grep Version
Version: 1.7.3
root@dev-maas-dev-dev0:/home/vagrant# sudo find /usr -name elasticsearch -type f
/usr/share/elasticsearch/bin/elasticsearch
```

Since we are within [the version window](https://www.elastic.co/guide/en/elasticsearch/reference/1.7/setup-upgrade.html), it is easier to roll forward with the ES upgrade than to revert and build a new package on buildbot.

One less package to maintain ❤️ 