### PR TITLE
Fix listen_address attribute 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.2
+- Revert listen_address logic that was removed but probably should not have been
+- Set min/max default to the same attribute (recommended best practice)
+
 # 0.1.1
 - Remove if logic from setting default listen_address to be a static IP
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,9 @@
-default['elasticsearch']['cluster_name'] = 'MyCluster'
-default['elasticsearch']['listen_address'] = '0.0.0.0'
+default['elasticsearch']['cluster_name'] = 'logstash_ele-dev'
+default['elasticsearch']['listen_address'] = begin
+                                               node['networks']['ipaddress_eth0']
+                                             rescue
+                                               '0.0.0.0'
+                                             end
 
 default['elasticsearch']['http_port'] = 9200
 default['elasticsearch']['transport_port'] = 9300
@@ -10,7 +14,7 @@ default['elasticsearch']['refresh_interval'] = '1s'
 default['elasticsearch']['cache_field_type'] = 'resident'
 default['elasticsearch']['seed_nodes'] = []
 
-default['elasticsearch']['es_min_mem'] = '512m'
+default['elasticsearch']['es_min_mem'] = '1g'
 default['elasticsearch']['es_max_mem'] = '1g'
 default['elasticsearch']['plugins'] = []
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures elasticsearch'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.2.1'
+version '0.2.2'
 
 depends 'ele-apt'
 depends 'iptables'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,7 +29,7 @@ if seed_nodes && seed_nodes.empty?
   search(:node, "(recipes:elasticsearch OR recipes:elasticsearch\\:\\:default) AND chef_environment:#{node.chef_environment}") do |n|
     if n['elasticsearch']['cluster_name'] == node['elasticsearch']['cluster_name']
       # |= only add node if doesn't already exist, just a failsafe
-      seed_nodes |= [n['elasticsearch']['listen_address']]
+      seed_nodes |= [n['networks']['ipaddress_eth0']]
     end
   end
 end

--- a/templates/default/elasticsearch.yml.erb
+++ b/templates/default/elasticsearch.yml.erb
@@ -3,7 +3,7 @@ cluster:
   name: <%= node['elasticsearch']['cluster_name'] %>
 
 network:
-  host: <%= node['elasticsearch']['listen_address'] %>
+  publish_host: <%= node['elasticsearch']['listen_address'] %>
 
 http:
   port: <%= node['elasticsearch']['http_port'] %>

--- a/test/unit/spec/spec_helper.rb
+++ b/test/unit/spec/spec_helper.rb
@@ -21,7 +21,7 @@ require 'chef/application'
 }.freeze
 
 def stub_resources
-  stub_search("node", "(recipes:elasticsearch OR recipes:elasticsearch\\:\\:default) AND chef_environment:_default").and_return(true)
+  stub_search('node', '(recipes:elasticsearch OR recipes:elasticsearch\\:\\:default) AND chef_environment:_default').and_return(true)
 end
 
 at_exit { ChefSpec::Coverage.report! }


### PR DESCRIPTION
## Description
Revert to the previous way we set the listen_address attribute.  Change seed_nodes attribute to get set by networks.ipaddress_eth0 instead of relying on elasticsearch.listen_address - as there may be times when you want listen_address to be a different IP address than what seed_nodes get populated with.  Note that seed_nodes is a bad variable name - these are really just worker or data nodes in the cluster (maybe seed nodes carried over from someone working cassandra - but isn't relavant afaik in elasticsearch speak).

I set the default cluster name to logstash_ele-dev instead of MyCluster as that seems to fit better in line with team standard.

Set the min and max default heap size to be the same per the elasticsearch documentation at https://www.elastic.co/guide/en/elasticsearch/guide/current/heap-sizing.html

Change the elasticsearch.yml template to specify publish_host (instead of host).  The host declaration sets both publish_host and bind_host.  If we leave bind_host unset it will default to run on both the eth0 IP address and localhost.  If there were public interfaces added to those hosts, we could use bind_host to be more specific.

## How to deploy/test
- [ ] Create a 0.2.2 tag and push to the repo.
- [ ] Update Berksfile in racker/chef to pull in updated cookbook.

Check that /etc/elasticsearch/elasticsearch.yml has correctly set network.host and discovery.zen.ping.unicast.hosts with hosts from the environment.  Should be 4 hosts in the unicast.hosts attribute.