### PR TITLE
pin Elasticsearch version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.5
+- pin Elasticsearch version
+
+# 0.2.4
+- remove hardcoded eth0 references
+
 # 0.2.3
 - add a sort on seed_nodes attribute to make it idempotent
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures elasticsearch'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.2.4'
+version '0.2.5'
 
 depends 'ele-apt'
 depends 'iptables'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -41,7 +41,7 @@ Chef::Log.debug("\e[32mElasticsearch:\e[33m computed seed_nodes: #{seed_nodes}.\
 include_recipe 'ele-apt'
 
 package 'elasticsearch' do
-  action :upgrade
+  version '1.7.3'
 end
 
 directory '/etc/elasticsearch' do

--- a/test/unit/spec/default_spec.rb
+++ b/test/unit/spec/default_spec.rb
@@ -14,7 +14,7 @@ describe 'elasticsearch::default' do
   #    expect(chef_run).to install_package('elasticsearch')
   #  end
   it 'upgrades a package with an explicit action' do
-    expect(chef_run).to upgrade_package('elasticsearch')
+    expect(chef_run).to install_package('elasticsearch').with(version: '1.7.3')
   end
 
   it 'creates a config template with an explicit action' do


### PR DESCRIPTION
# why

Filebeat apt repo provides newer ES versions than we want to use.

Since this would be a major version downgrade, it will have to be done manually. This PR is just to keep chef from re-upgrading prematurely in the future.

# TODO

- [x] confirm we can run old ES with new filebeat
- [x] downgrade ES
- [x] rebuild indexes
- [ ] merge this && update Berkshelf
