### PR TITLE
staging has extra disks mounted, lets use them

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -68,11 +68,18 @@ directory '/var/lib/elasticsearch' do
   mode 0o700
 end
 
+if node.chef_environment == 'stage'
+  path_data = '/data/elasticsearch'
+else
+  path_data = '/var/lib/elasticsearch'
+end
+
 template '/etc/elasticsearch/elasticsearch.yml' do
   source 'elasticsearch.yml.erb'
   mode 0o0644
   variables(
     seed_nodes: seed_nodes,
+    path_data: path_data,
     client_only: false
   )
   notifies :restart, 'service[elasticsearch]', :delayed

--- a/templates/default/elasticsearch.yml.erb
+++ b/templates/default/elasticsearch.yml.erb
@@ -41,6 +41,6 @@ bootstrap:
   mlockall: true
 
 path:
-  data: /var/lib/elasticsearch
+  data: <%= @path_data %>
   conf: /etc/elasticsearch
   work: /tmp/elasticsearch


### PR DESCRIPTION
staging nodes have an extra 3+T mounted at `/data` that was previously used, but is no longer, lets start using that again.

```
shawn@log2.dfw1.stage:~ $ df -h
Filesystem      Size  Used Avail Use% Mounted on
udev             32G  4.0K   32G   1% /dev
tmpfs           6.3G  680K  6.3G   1% /run
/dev/sda1       212G  178G   23G  89% /
none            4.0K     0  4.0K   0% /sys/fs/cgroup
none            5.0M     0  5.0M   0% /run/lock
none             32G     0   32G   0% /run/shm
none            100M     0  100M   0% /run/user
/dev/sdb1       3.3T  1.1T  2.2T  34% /data
```